### PR TITLE
refactor: change the packageName to packagename

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a template reference for hexagonal spring boot. This repository 
 
 The keywords of the app-generators are the following
 
-- `packageName` - to rename the package names
+- `packagename` - to rename the package names
 - `artifactName` - to rename the artifact id
 - `Example` - to rename class, variables 
 

--- a/acceptance-test/src/test/java/packageName/AcceptanceTest.java
+++ b/acceptance-test/src/test/java/packageName/AcceptanceTest.java
@@ -1,4 +1,4 @@
-package packageName;
+package packagename;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,11 +11,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import packageName.domain.ExampleDomain;
-import packageName.domain.model.Example;
-import packageName.domain.model.ExampleInfo;
-import packageName.domain.port.ObtainExample;
-import packageName.domain.port.RequestExample;
+import packagename.domain.ExampleDomain;
+import packagename.domain.model.Example;
+import packagename.domain.model.ExampleInfo;
+import packagename.domain.port.ObtainExample;
+import packagename.domain.port.RequestExample;
 
 @ExtendWith(MockitoExtension.class)
 @RunWith(JUnitPlatform.class)

--- a/acceptance-test/src/test/java/packageName/AcceptanceTest.java
+++ b/acceptance-test/src/test/java/packageName/AcceptanceTest.java
@@ -6,8 +6,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,7 +16,6 @@ import packagename.domain.port.ObtainExample;
 import packagename.domain.port.RequestExample;
 
 @ExtendWith(MockitoExtension.class)
-@RunWith(JUnitPlatform.class)
 public class AcceptanceTest {
 
   @Test

--- a/acceptance-test/src/test/java/packageName/ExampleE2EApplication.java
+++ b/acceptance-test/src/test/java/packageName/ExampleE2EApplication.java
@@ -1,14 +1,14 @@
-package packageName;
+package packagename;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import packageName.domain.ExampleDomain;
-import packageName.domain.port.ObtainExample;
-import packageName.domain.port.RequestExample;
-import packageName.repository.config.JpaAdapterConfig;
+import packagename.domain.ExampleDomain;
+import packagename.domain.port.ObtainExample;
+import packagename.domain.port.RequestExample;
+import packagename.repository.config.JpaAdapterConfig;
 
 @SpringBootApplication
 public class ExampleE2EApplication {

--- a/acceptance-test/src/test/java/packageName/cucumber/ExampleStepDef.java
+++ b/acceptance-test/src/test/java/packageName/cucumber/ExampleStepDef.java
@@ -1,4 +1,4 @@
-package packageName.cucumber;
+package packagename.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -17,11 +17,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import packageName.ExampleE2EApplication;
-import packageName.domain.model.Example;
-import packageName.domain.model.ExampleInfo;
-import packageName.repository.dao.ExampleDao;
-import packageName.repository.entity.ExampleEntity;
+import packagename.ExampleE2EApplication;
+import packagename.domain.model.Example;
+import packagename.domain.model.ExampleInfo;
+import packagename.repository.dao.ExampleDao;
+import packagename.repository.entity.ExampleEntity;
 
 
 @ExtendWith(SpringExtension.class)

--- a/acceptance-test/src/test/java/packageName/cucumber/RunCucumberExampleTest.java
+++ b/acceptance-test/src/test/java/packageName/cucumber/RunCucumberExampleTest.java
@@ -1,4 +1,4 @@
-package packageName.cucumber;
+package packagename.cucumber;
 
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "classpath:features", strict = true, plugin = {"json:target/cucumber/example.json", "json:target/cucumber/example.xml"}, tags = {
-    "@Example"}, glue = "classpath:packageName.cucumber")
+    "@Example"}, glue = "classpath:packagename.cucumber")
 public class RunCucumberExampleTest {
 
 }

--- a/bootstrap/src/main/java/packageName/boot/ExampleApplication.java
+++ b/bootstrap/src/main/java/packageName/boot/ExampleApplication.java
@@ -1,11 +1,11 @@
-package packageName.boot;
+package packagename.boot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = "packageName")
+@ComponentScan(basePackages = "packagename")
 public class ExampleApplication {
 
   public static void main(String[] args) {

--- a/bootstrap/src/main/java/packageName/boot/config/BootstrapConfig.java
+++ b/bootstrap/src/main/java/packageName/boot/config/BootstrapConfig.java
@@ -1,12 +1,12 @@
-package packageName.boot.config;
+package packagename.boot.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import packageName.domain.ExampleDomain;
-import packageName.domain.port.ObtainExample;
-import packageName.domain.port.RequestExample;
-import packageName.repository.config.JpaAdapterConfig;
+import packagename.domain.ExampleDomain;
+import packagename.domain.port.ObtainExample;
+import packagename.domain.port.RequestExample;
+import packagename.repository.config.JpaAdapterConfig;
 
 @Configuration
 @Import(JpaAdapterConfig.class)

--- a/domain-api/src/main/java/packageName/domain/exception/ExampleNotFoundException.java
+++ b/domain-api/src/main/java/packageName/domain/exception/ExampleNotFoundException.java
@@ -1,4 +1,4 @@
-package packageName.domain.exception;
+package packagename.domain.exception;
 
 public class ExampleNotFoundException extends RuntimeException {
 }

--- a/domain-api/src/main/java/packageName/domain/model/Example.java
+++ b/domain-api/src/main/java/packageName/domain/model/Example.java
@@ -1,4 +1,4 @@
-package packageName.domain.model;
+package packagename.domain.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/domain-api/src/main/java/packageName/domain/model/ExampleInfo.java
+++ b/domain-api/src/main/java/packageName/domain/model/ExampleInfo.java
@@ -1,4 +1,4 @@
-package packageName.domain.model;
+package packagename.domain.model;
 
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/domain-api/src/main/java/packageName/domain/port/ObtainExample.java
+++ b/domain-api/src/main/java/packageName/domain/port/ObtainExample.java
@@ -1,7 +1,7 @@
-package packageName.domain.port;
+package packagename.domain.port;
 
 import java.util.List;
-import packageName.domain.model.Example;
+import packagename.domain.model.Example;
 
 public interface ObtainExample {
 

--- a/domain-api/src/main/java/packageName/domain/port/RequestExample.java
+++ b/domain-api/src/main/java/packageName/domain/port/RequestExample.java
@@ -1,6 +1,6 @@
-package packageName.domain.port;
+package packagename.domain.port;
 
-import packageName.domain.model.ExampleInfo;
+import packagename.domain.model.ExampleInfo;
 
 public interface RequestExample {
 

--- a/domain/src/main/java/packageName/domain/ExampleDomain.java
+++ b/domain/src/main/java/packageName/domain/ExampleDomain.java
@@ -1,8 +1,8 @@
-package packageName.domain;
+package packagename.domain;
 
-import packageName.domain.model.ExampleInfo;
-import packageName.domain.port.ObtainExample;
-import packageName.domain.port.RequestExample;
+import packagename.domain.model.ExampleInfo;
+import packagename.domain.port.ObtainExample;
+import packagename.domain.port.RequestExample;
 
 public class ExampleDomain implements RequestExample {
 

--- a/jpa-adapter/src/main/java/packageName/repository/ExampleRepository.java
+++ b/jpa-adapter/src/main/java/packageName/repository/ExampleRepository.java
@@ -1,11 +1,11 @@
-package packageName.repository;
+package packagename.repository;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import packageName.domain.model.Example;
-import packageName.domain.port.ObtainExample;
-import packageName.repository.dao.ExampleDao;
-import packageName.repository.entity.ExampleEntity;
+import packagename.domain.model.Example;
+import packagename.domain.port.ObtainExample;
+import packagename.repository.dao.ExampleDao;
+import packagename.repository.entity.ExampleEntity;
 
 public class ExampleRepository implements ObtainExample {
 

--- a/jpa-adapter/src/main/java/packageName/repository/config/JpaAdapterConfig.java
+++ b/jpa-adapter/src/main/java/packageName/repository/config/JpaAdapterConfig.java
@@ -1,16 +1,16 @@
-package packageName.repository.config;
+package packagename.repository.config;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import packageName.domain.port.ObtainExample;
-import packageName.repository.ExampleRepository;
-import packageName.repository.dao.ExampleDao;
+import packagename.domain.port.ObtainExample;
+import packagename.repository.ExampleRepository;
+import packagename.repository.dao.ExampleDao;
 
 @Configuration
-@EntityScan("packageName.repository.entity")
-@EnableJpaRepositories("packageName.repository.dao")
+@EntityScan("packagename.repository.entity")
+@EnableJpaRepositories("packagename.repository.dao")
 public class JpaAdapterConfig {
 
   @Bean

--- a/jpa-adapter/src/main/java/packageName/repository/dao/ExampleDao.java
+++ b/jpa-adapter/src/main/java/packageName/repository/dao/ExampleDao.java
@@ -1,8 +1,8 @@
-package packageName.repository.dao;
+package packagename.repository.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import packageName.repository.entity.ExampleEntity;
+import packagename.repository.entity.ExampleEntity;
 
 @Repository
 public interface ExampleDao extends JpaRepository<ExampleEntity, Long> {

--- a/jpa-adapter/src/main/java/packageName/repository/entity/ExampleEntity.java
+++ b/jpa-adapter/src/main/java/packageName/repository/entity/ExampleEntity.java
@@ -1,4 +1,4 @@
-package packageName.repository.entity;
+package packagename.repository.entity;
 
 import static javax.persistence.GenerationType.AUTO;
 
@@ -11,7 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import packageName.domain.model.Example;
+import packagename.domain.model.Example;
 
 @Table(name = "T_EXAMPLE")
 @Entity

--- a/jpa-adapter/src/test/java/packageName/repository/ExampleJpaAdapterApplication.java
+++ b/jpa-adapter/src/test/java/packageName/repository/ExampleJpaAdapterApplication.java
@@ -1,11 +1,11 @@
-package packageName.repository;
+package packagename.repository;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import packageName.domain.port.ObtainExample;
-import packageName.repository.dao.ExampleDao;
+import packagename.domain.port.ObtainExample;
+import packagename.repository.dao.ExampleDao;
 
 @SpringBootApplication
 public class ExampleJpaAdapterApplication {

--- a/jpa-adapter/src/test/java/packageName/repository/ExampleJpaTest.java
+++ b/jpa-adapter/src/test/java/packageName/repository/ExampleJpaTest.java
@@ -1,4 +1,4 @@
-package packageName.repository;
+package packagename.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import packageName.domain.model.Example;
-import packageName.domain.port.ObtainExample;
+import packagename.domain.model.Example;
+import packagename.domain.port.ObtainExample;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest

--- a/rest-adapter/src/main/java/packageName/rest/ExampleResource.java
+++ b/rest-adapter/src/main/java/packageName/rest/ExampleResource.java
@@ -1,11 +1,11 @@
-package packageName.rest;
+package packagename.rest;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import packageName.domain.model.ExampleInfo;
-import packageName.domain.port.RequestExample;
+import packagename.domain.model.ExampleInfo;
+import packagename.domain.port.RequestExample;
 
 @RestController
 @RequestMapping("/api/v1/examples")

--- a/rest-adapter/src/main/java/packageName/rest/exception/ExampleExceptionHandler.java
+++ b/rest-adapter/src/main/java/packageName/rest/exception/ExampleExceptionHandler.java
@@ -1,4 +1,4 @@
-package packageName.rest.exception;
+package packagename.rest.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -6,9 +6,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
-import packageName.domain.exception.ExampleNotFoundException;
+import packagename.domain.exception.ExampleNotFoundException;
 
-@RestControllerAdvice(basePackages = {"packageName"})
+@RestControllerAdvice(basePackages = {"packagename"})
 public class ExampleExceptionHandler {
 
   @ExceptionHandler(value = ExampleNotFoundException.class)

--- a/rest-adapter/src/main/java/packageName/rest/exception/ExampleExceptionResponse.java
+++ b/rest-adapter/src/main/java/packageName/rest/exception/ExampleExceptionResponse.java
@@ -1,4 +1,4 @@
-package packageName.rest.exception;
+package packagename.rest.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/rest-adapter/src/test/java/packageName/rest/ExamplePoetryRestAdapterApplication.java
+++ b/rest-adapter/src/test/java/packageName/rest/ExamplePoetryRestAdapterApplication.java
@@ -1,13 +1,13 @@
-package packageName.rest;
+package packagename.rest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
-import packageName.domain.port.RequestExample;
+import packagename.domain.port.RequestExample;
 
 @SpringBootApplication
-@ComponentScan(basePackages = "packageName")
+@ComponentScan(basePackages = "packagename")
 public class ExamplePoetryRestAdapterApplication {
 
   @MockBean

--- a/rest-adapter/src/test/java/packageName/rest/ExampleResourceTest.java
+++ b/rest-adapter/src/test/java/packageName/rest/ExampleResourceTest.java
@@ -1,4 +1,4 @@
-package packageName.rest;
+package packagename.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -17,9 +17,9 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import packageName.domain.model.Example;
-import packageName.domain.model.ExampleInfo;
-import packageName.domain.port.RequestExample;
+import packagename.domain.model.Example;
+import packagename.domain.model.ExampleInfo;
+import packagename.domain.port.RequestExample;
 
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(classes = ExamplePoetryRestAdapterApplication.class, webEnvironment = RANDOM_PORT)


### PR DESCRIPTION
# Description
When we have `packageName' as the name of a package then its not a java standard because it should essentially be all lower case however we have used camelCase.

<!-- Description about this pull request -->

Closes : <!-- refer the github issue. Ex: #084-->
https://github.com/devs-from-matrix/hexagonal-spring-boot-java/issues/13
# Checklist:

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
