### PR TITLE
build: bump versions to latest

### DIFF
--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -31,36 +31,18 @@
       <artifactId>cucumber-java8</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apiguardian</groupId>
-          <artifactId>apiguardian-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
-      <artifactId>cucumber-junit</artifactId>
+      <artifactId>cucumber-junit-platform-engine</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apiguardian</groupId>
-          <artifactId>apiguardian-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-spring</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apiguardian</groupId>
-          <artifactId>apiguardian-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -9,6 +9,9 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>acceptance-test</artifactId>
+  <properties>
+    <io.cucumber-message.version>17.1.1</io.cucumber-message.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>packagename</groupId>
@@ -31,6 +34,17 @@
       <artifactId>cucumber-java8</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.cucumber</groupId>
+          <artifactId>messages</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>messages</artifactId>
+      <version>${io.cucumber-message.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>

--- a/acceptance-test/src/test/java/packagename/cucumber/ExampleStepDef.java
+++ b/acceptance-test/src/test/java/packagename/cucumber/ExampleStepDef.java
@@ -1,34 +1,23 @@
 package packagename.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java8.En;
 import io.cucumber.java8.HookNoArgsBody;
-import io.cucumber.spring.CucumberContextConfiguration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import packagename.boot.ExampleApplication;
 import packagename.domain.model.Example;
 import packagename.domain.model.ExampleInfo;
 import packagename.repository.dao.ExampleDao;
 import packagename.repository.entity.ExampleEntity;
 import packagename.rest.exception.ExampleExceptionResponse;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = ExampleApplication.class, webEnvironment = RANDOM_PORT)
-@CucumberContextConfiguration
-@ActiveProfiles("test")
 public class ExampleStepDef implements En {
 
   private static final String LOCALHOST = "http://localhost:";

--- a/acceptance-test/src/test/java/packagename/cucumber/RunCucumberExampleTest.java
+++ b/acceptance-test/src/test/java/packagename/cucumber/RunCucumberExampleTest.java
@@ -1,13 +1,21 @@
 package packagename.cucumber;
 
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
-import org.junit.runner.RunWith;
+import static io.cucumber.junit.platform.engine.Constants.*;
 
-@RunWith(Cucumber.class)
-@CucumberOptions(
-    features = "classpath:features",
-    plugin = {"json:target/cucumber/example.json", "json:target/cucumber/example.xml"},
-    tags = "@Example",
-    glue = "classpath:packagename.cucumber")
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features/example.feature")
+@ConfigurationParameters({
+  @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "packagename.cucumber"),
+  @ConfigurationParameter(key = FILTER_TAGS_PROPERTY_NAME, value = "@Example"),
+  @ConfigurationParameter(key = JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, value = "long"),
+  @ConfigurationParameter(key = PLUGIN_PUBLISH_QUIET_PROPERTY_NAME, value = "true"),
+  @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber/cucumber.json")
+})
 public class RunCucumberExampleTest {}

--- a/acceptance-test/src/test/java/packagename/cucumber/SpringCucumberTestConfig.java
+++ b/acceptance-test/src/test/java/packagename/cucumber/SpringCucumberTestConfig.java
@@ -1,0 +1,13 @@
+package packagename.cucumber;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import packagename.boot.ExampleApplication;
+
+@SpringBootTest(classes = ExampleApplication.class, webEnvironment = RANDOM_PORT)
+@CucumberContextConfiguration
+@ActiveProfiles("test")
+public class SpringCucumberTestConfig {}

--- a/jpa-adapter/pom.xml
+++ b/jpa-adapter/pom.xml
@@ -19,10 +19,30 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.roo</groupId>
+          <artifactId>org.springframework.roo.annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-envers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.roo</groupId>
+          <artifactId>org.springframework.roo.annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.6</spring-boot.version>
     <cucumber.version>6.11.0</cucumber.version>
-    <springdoc.version>1.5.10</springdoc.version>
+    <springdoc.version>1.5.12</springdoc.version>
     <pre-liquibase.version>1.1.1</pre-liquibase.version>
     <!-- plugins -->
     <cukedoctor-maven-plugin.version>3.7.0</cukedoctor-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,9 @@
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <junit-jupiter.version>5.8.1</junit-jupiter.version>
     <spring-boot.version>2.5.6</spring-boot.version>
-    <cucumber.version>6.11.0</cucumber.version>
+    <cucumber.version>7.0.0</cucumber.version>
     <springdoc.version>1.5.12</springdoc.version>
     <pre-liquibase.version>1.1.1</pre-liquibase.version>
     <!-- plugins -->
@@ -64,6 +65,13 @@
       </dependency>
       <!-- Frameworks & Libraries -->
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
@@ -93,22 +101,12 @@
     <!-- JUnit 5 dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
+      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- mockito dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <!-- plugins -->
     <cukedoctor-maven-plugin.version>3.7.0</cukedoctor-maven-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-enforcer-plugin>3.0.0-M3</maven-enforcer-plugin>
+    <maven-enforcer-plugin>3.0.0</maven-enforcer-plugin>
     <arch-unit-maven-plugin.version>2.8.0</arch-unit-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
# Description

- Spring-boot: 2.5.6
- Springdoc: 1.5.12
- cucumber: 7.0.0
- maven-enforcer-plugin: 3.0.0
- junit bom: 5.8.1

## Breaking changes while upgrading

### Cucumber: `7.0.0`

Lambda's (cucumber-java8) does not work well with the `CucumberContextConfiguration` in the same file. Hence had to extract it to a different class from the StepDef as suggested in as suggested in cucumber/cucumber-jvm#2413

### maven-enforcer-plugin: `3.0.0`

This is an issue with legacy `org.springframework.roo.annotations` dependency as mentioned in https://github.com/spring-projects/spring-data-jpa/issues/2285 which refers to a repository which is not actually present in maven central but at https://spring-roo-repository.springsource.org/release. Since the resource of this dependency is not used this template we can as well exclude it as mentioned in https://github.com/spring-projects/spring-data-jpa/issues/2347


```xml
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter-data-jpa</artifactId>
  <exclusions>
    <exclusion>
      <groupId>org.springframework.roo</groupId>
      <artifactId>org.springframework.roo.annotations</artifactId>
    </exclusion>
  </exclusions>
</dependency>
<dependency>
  <groupId>org.springframework.data</groupId>
  <artifactId>spring-data-envers</artifactId>
  <exclusions>
    <exclusion>
      <groupId>org.springframework.roo</groupId>
      <artifactId>org.springframework.roo.annotations</artifactId>
    </exclusion>
  </exclusions>
</dependency>
```

# Checklist:

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
